### PR TITLE
reaction commands

### DIFF
--- a/main.py
+++ b/main.py
@@ -210,67 +210,68 @@ async def on_message(message: discord.Message) -> None:
 # Reaction added
 @bot.event
 async def on_reaction_add(reaction: discord.Reaction, user: discord.User) -> None:
-    if str(reaction.emoji) in ["❓", "❔", "🔒", "🔓", "🔐"] and reaction.message.author.bot and reaction.message.author != bot.user:
-        # Check if reaction is reacting to a message sent by a transformed user
-        # I know this isn't the most efficient method, but it's really the best we have, at least for now
-        # TODO: Find a better way to do this (maybe?)
-        tfee, data = utils.check_reactions(reaction)
-        if not tfee:
-            return
-        if str(reaction.emoji) == "❓" or str(reaction.emoji) == "❔":
-            await user.send(f"\"{reaction.message.author.name}\" is, in fact, {bot.get_user(int(tfee)).mention}!\n"
-                            f"(Transformed by {bot.get_user(int(data['transformed_by'])).mention})")
+    if str(reaction.emoji) not in ["❓", "❔", "🔒", "🔓", "🔐"] or not reaction.message.author.bot or reaction.message.author == bot.user:
+        return
+
+    # Check if reaction is reacting to a message sent by a transformed user
+    # I know this isn't the most efficient method, but it's really the best we have, at least for now
+    # TODO: Find a better way to do this (maybe?)
+    tfee, data = utils.check_reactions(reaction)
+    if not tfee:
+        return
+    if str(reaction.emoji) in ["❓", "❔"]:
+        await user.send(f"\"{reaction.message.author.name}\" is, in fact, {bot.get_user(tfee).mention}!\n"
+                        f"(Transformed by {bot.get_user(int(data['transformed_by'])).mention})")
+        await reaction.remove(user)
+        return
+    data_claim = data['claim']
+    if str(reaction.emoji) == "🔒":
+        # Check if the tfee is already claimed
+        if data_claim not in ["", None]:
+            await user.send(f"\"{reaction.message.author.name}\" is already claimed by {data_claim}!")
             await reaction.remove(user)
             return
-        if str(reaction.emoji) == "🔒":
-            # Check if the tfee is already claimed
-            if data['claim'] not in ["", None]:
-                await user.send(f"\"{reaction.message.author.name}\" is already claimed by {data['claim']}!")
+        utils.write_tf(bot.get_user(tfee), reaction.message.guild, claim_user=user.name)
+        await user.send(f"Successfully claimed \"{reaction.message.author.name}\" for yourself!")
+        await reaction.message.channel.send(f"{user.mention} has claimed \"{reaction.message.author.name}\"!")
+        await reaction.remove(user)
+        return
+    if str(reaction.emoji) == "🔓":
+        # Check if the tfee is already claimed
+        if data_claim in ["", None]:
+            await user.send(f"\"{reaction.message.author.name}\" is not claimed by anyone!")
+            await reaction.remove(user)
+            return
+        if data_claim != user.name:
+            await user.send(f"\"{reaction.message.author.name}\" is claimed by {data_claim}! You can't unclaim them!")
+            await reaction.remove(user)
+            return
+        utils.write_tf(bot.get_user(tfee), reaction.message.guild, claim_user="", eternal=0)
+        await user.send(f"Successfully unclaimed \"{reaction.message.author.name}\"!")
+        await reaction.message.channel.send(f"{user.mention} has unclaimed \"{reaction.message.author.name}\"!")
+        await reaction.remove(user)
+        return
+    if str(reaction.emoji) == "🔐":
+        if data['eternal']:
+            if data_claim != user.name:
+                await user.send(f"\"{reaction.message.author.name}\" is eternally transformed by {data_claim}!"
+                                f"You can't free them!")
                 await reaction.remove(user)
                 return
-            else:
-                utils.write_tf(bot.get_user(int(tfee)), reaction.message.guild, claim_user=user.name)
-                await user.send(f"Successfully claimed \"{reaction.message.author.name}\" for yourself!")
-                await reaction.message.channel.send(f"{user.mention} has claimed \"{reaction.message.author.name}\"!")
-                await reaction.remove(user)
-                return
-        if str(reaction.emoji) == "🔓":
-            # Check if the tfee is already claimed
-            if data['claim'] in ["", None]:
-                await user.send(f"\"{reaction.message.author.name}\" is not claimed by anyone!")
-                await reaction.remove(user)
-                return
-            elif data['claim'] != user.name:
-                await user.send(f"\"{reaction.message.author.name}\" is claimed by {data['claim']}! You can't unclaim them!")
-                await reaction.remove(user)
-                return
-            else:
-                utils.write_tf(bot.get_user(int(tfee)), reaction.message.guild, claim_user="")
-                utils.write_tf(bot.get_user(int(tfee)), reaction.message.guild, eternal=0)
-                await user.send(f"Successfully unclaimed \"{reaction.message.author.name}\"!")
-                await reaction.message.channel.send(f"{user.mention} has unclaimed \"{reaction.message.author.name}\"!")
-                await reaction.remove(user)
-                return
-        if str(reaction.emoji) == "🔐" :
-            if data['eternal'] and data['claim'] == user.name:
-                # Clear the eternal transformation
-                utils.write_tf(bot.get_user(int(tfee)), reaction.message.guild, eternal=0)
-                await user.send(f"Successfully un-eternally transformed \"{reaction.message.author.name}\"!")
-                await reaction.message.channel.send(f"{user.mention} has un-eternally transformed \"{reaction.message.author.name}\"!")
-                await reaction.remove(user)
-                return
-            elif data['eternal'] and data['claim'] != user.name:
-                await user.send(f"\"{reaction.message.author.name}\" is eternally transformed by {data['claim']}! You can't free them!")
-                await reaction.remove(user)
-                return
-            else:
-                utils.write_tf(bot.get_user(int(tfee)), reaction.message.guild, eternal=1, claim_user=user.name)
-                await user.send(f"Successfully eternally transformed \"{reaction.message.author.name}\"!")
-                await reaction.message.channel.send(f"{user.mention} has eternally transformed \"{reaction.message.author.name}\"!")
-                await reaction.remove(user)
-                return
+            # Clear the eternal transformation
+            utils.write_tf(bot.get_user(tfee), reaction.message.guild, eternal=0)
+            await user.send(f"Successfully un-eternally transformed \"{reaction.message.author.name}\"!")
+            await reaction.message.channel.send(f"{user.mention} has un-eternally transformed"
+                                                f"\"{reaction.message.author.name}\"!")
+            await reaction.remove(user)
+            return
 
-    # Refactor to check 
+        utils.write_tf(bot.get_user(tfee), reaction.message.guild, eternal=1, claim_user=user.name)
+        await user.send(f"Successfully eternally transformed \"{reaction.message.author.name}\"!")
+        await reaction.message.channel.send(f"{user.mention} has eternally transformed"
+                                            f"\"{reaction.message.author.name}\"!")
+        await reaction.remove(user)
+        return
 
 
 # Transformation commands

--- a/utils.py
+++ b/utils.py
@@ -359,11 +359,11 @@ def get_embed_base(title: str, desc: str = None) -> discord.Embed:
     )
 
 
-def check_reactions(reaction) -> object:
+def check_reactions(reaction: discord.Reaction) -> [int, dict]:
     tfee_data = load_transformed(reaction.message.guild)['transformed_users']
     for tfee in tfee_data:
         data = load_tf_by_id(tfee, reaction.message.guild)
         data = data[str(reaction.message.channel.id)] if str(reaction.message.channel.id) in data else data['all']
         if data['into'] == reaction.message.author.name:
-            return [tfee, data]
+            return [int(tfee), data]
     return [None, None]

--- a/utils.py
+++ b/utils.py
@@ -221,6 +221,8 @@ def remove_transformed(user: discord.User, guild: discord.Guild, channel: discor
 
 def is_transformed(user: discord.User, guild: discord.Guild, channel: discord.TextChannel = None) -> bool:
     tfee_data = load_transformed(guild)
+    if tfee_data is None:
+        return False
     if tfee_data == {} or str(user.id) not in tfee_data['transformed_users']:
         return False
     if tfee_data['transformed_users'][str(user.id)] not in [[], None] and \
@@ -355,3 +357,13 @@ def get_embed_base(title: str, desc: str = None) -> discord.Embed:
             icon_url="https://cdn.discordapp.com/avatars/967123840587141181/46a629c191f53ec9d446ed4b712fb39b.png"
         )
     )
+
+
+def check_reactions(reaction) -> object:
+    tfee_data = load_transformed(reaction.message.guild)['transformed_users']
+    for tfee in tfee_data:
+        data = load_tf_by_id(tfee, reaction.message.guild)
+        data = data[str(reaction.message.channel.id)] if str(reaction.message.channel.id) in data else data['all']
+        if data['into'] == reaction.message.author.name:
+            return [tfee, data]
+    return [None, None]


### PR DESCRIPTION
Grabbing user now moved to utils.py, users able to claim and eternal via reactions on a transformed user's message.

**POSSIBLE PROBLEM WITH CURRENT METHOD**: users that have the same name for their transformation (i.e. twinning) will have the user that happens to have the numerical id that goes first be affected over a different one.